### PR TITLE
Edit mutpy for our use

### DIFF
--- a/mutpy/mutpy/controller.py
+++ b/mutpy/mutpy/controller.py
@@ -1,6 +1,7 @@
 import random
 import sys
 import time
+from copy import deepcopy
 
 from mutpy import views, utils
 
@@ -94,8 +95,8 @@ class MutationController(views.ViewNotifier):
             result, duration = self.run_test(test_module, target_test)
             if result.was_successful():
                 test_modules.append((test_module, target_test, duration))
-            else:
-                raise TestsFailAtOriginal(result)
+            # else:
+            #     raise TestsFailAtOriginal(result)
             number_of_tests += result.tests_run()
             total_duration += duration
 
@@ -110,8 +111,33 @@ class MutationController(views.ViewNotifier):
         coverage_injector, coverage_result = self.inject_coverage(target_ast, target_module)
         if coverage_injector:
             self.score.update_coverage(*coverage_injector.get_result())
+        
+        # STOP HERE AND ACCUMULATE MUTANTS
+        # SHUFFLE THE MUTANTS
+        mutant_list = []
         for mutations, mutant_ast in self.mutant_generator.mutate(target_ast, to_mutate, coverage_injector,
                                                                   module=target_module):
+            mutant_list.append((mutations, deepcopy(mutant_ast)))
+        random.shuffle(mutant_list)
+
+        # line2mutants = {}
+        # run the mutants
+        for mutations, mutant_ast in mutant_list:
+            # mutant_lineno = mutations[0].node.lineno
+
+            # # THIS CODE LIMITS MUTATION TESTING ON MUTANTS POSITIONED AT LINES_BY_FAILING_TC
+            # if mutant_lineno not in []:
+            #     continue
+
+
+            # # THIS CODE LIMITS MUTATION TESTING ON A SINGLE LINE TO MAX_NUM_MUTANTS_PER_LINE
+            # if mutant_lineno not in line2mutants:
+            #     line2mutants[mutant_lineno] = 0
+            # line2mutants[mutant_lineno] += 1
+            # if line2mutants[mutant_lineno] > 5:
+            #     continue
+
+
             mutation_number = self.score.all_mutants + 1
             if self.mutation_number and self.mutation_number != mutation_number:
                 self.score.inc_incompetent()

--- a/mutpy/mutpy/test_runners/base.py
+++ b/mutpy/mutpy/test_runners/base.py
@@ -56,6 +56,9 @@ SerializableMutationTestResult = namedtuple(
         'is_incompetent',
         'is_survived',
         'killer',
+        'killers',
+        'passings',
+        'failings',
         'exception_traceback',
         'exception',
         'tests_run',
@@ -90,6 +93,21 @@ class MutationTestResult:
         if killer:
             return killer.name
 
+    def _get_killers(self):
+        if self.failed:
+            return self.failed
+    
+    def get_killers(self):
+        killers = self._get_killers()
+        if killers:
+            return [killer.name for killer in killers]
+    
+    def get_passings(self):
+        return self.passed
+    
+    def get_failings(self):
+        return self.failed
+
     def get_exception_traceback(self):
         killer = self._get_killer()
         if killer:
@@ -109,6 +127,9 @@ class MutationTestResult:
             self.is_incompetent(),
             self.is_survived(),
             str(self.get_killer()),
+            self.get_killers(),
+            self.get_passings(),
+            self.get_failings(),
             str(self.get_exception_traceback()),
             self.get_exception(),
             self.tests_run() - self.tests_skipped(),

--- a/mutpy/mutpy/test_runners/pytest_runner.py
+++ b/mutpy/mutpy/test_runners/pytest_runner.py
@@ -80,7 +80,7 @@ class PytestTestSuite(BaseTestSuite):
 
     def run(self):
         mutpy_plugin = PytestMutpyPlugin(skipped_tests=self.skipped_tests)
-        pytest.main(args=list(self.tests) + ['-x', '-p', 'no:terminal'], plugins=list(default_plugins) + [mutpy_plugin])
+        pytest.main(args=list(self.tests) + ['-p', 'no:terminal'], plugins=list(default_plugins) + [mutpy_plugin])
         return mutpy_plugin.mutation_test_result
 
     def run_with_coverage(self, coverage_injector=None):

--- a/mutpy/mutpy/test_runners/unittest_runner.py
+++ b/mutpy/mutpy/test_runners/unittest_runner.py
@@ -8,7 +8,7 @@ class UnittestMutationTestResult(unittest.TestResult):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.type_error = None
-        self.failfast = True
+        self.failfast = False
         self.mutation_test_result = MutationTestResult()
 
     def addSuccess(self, test):

--- a/wally.py
+++ b/wally.py
@@ -1,0 +1,17 @@
+#!/usr/bin/python3
+import sys
+sys.path.append('.')
+import argparse
+
+# from mutpy import commandline
+
+# --save-failinglines
+
+# failing_lines = {
+#     'tc1': [10, 11, 12, 13, 14, 15, 16, 17, 18, 19],
+# }
+
+# import json
+# json.dump(failing_lines, open('failing_lines.json', 'w'))
+
+# commandline.main(sys.argv[1:])


### PR DESCRIPTION
Edit mutpy to:
    - randomize mutation operation order
    - disable failfast for pytest and unittest
    - enable mutpy to run even with failing TC as the original test suite
  
Inititate wally.py